### PR TITLE
Use launch profile for seed data

### DIFF
--- a/GarageThree.Web/Program.cs
+++ b/GarageThree.Web/Program.cs
@@ -23,9 +23,11 @@ if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "DevCo
 {
     app.UseDeveloperExceptionPage();
 
-    // Suggest we keep this outcommented, otherwise the db will be deleted, rebuilt and inserted with new data everytime the application starts
-    // Uncomment this line when you need to rebuild and seed your database
-    //await app.SeedDataAsync();
+    // dotnet run -lp Seed-Data
+    if (Environment.GetEnvironmentVariable("SEED_DATA") == "1")
+    {
+        await app.SeedDataAsync();
+    }
 }
 
 app.UseRouting();

--- a/GarageThree.Web/Properties/launchSettings.json
+++ b/GarageThree.Web/Properties/launchSettings.json
@@ -18,6 +18,15 @@
         "ASPNETCORE_ENVIRONMENT": "DevContainers"
       }
     },
+    "Seed-Data": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:3000",
+      "environmentVariables": {
+        "SEED_DATA": "1"
+      },
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/GarageThree.Web/ViewModels/Member/MemberViewModel.cs
+++ b/GarageThree.Web/ViewModels/Member/MemberViewModel.cs
@@ -1,17 +1,15 @@
-﻿using GarageThree.Web.ViewModels.Vehicle;
-
-namespace GarageThree.Web.ViewModels.Member
+﻿namespace GarageThree.Web.ViewModels.Member
 {
     public class MemberViewModel
     {
         public int Id { get; set; }
-        public string Avatar { get; set; }
-        public string Username { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+        public string Avatar { get; set; } = default!;
+        public string Username { get; set; } = default!;
+        public string FirstName { get; set; } = default!;
+        public string LastName { get; set; } = default!;
         public int Age { get; set; }
-        public string Email { get; set; }
-        public string SSN { get; set; }
+        public string Email { get; set; } = default!;
+        public string SSN { get; set; } = default!;
 
         public IEnumerable<VehicleViewModel> Vehicles { get; set; } = [];
     }


### PR DESCRIPTION
Not sure how to launch with a profile in Visual Studio, but it has to be possible.

This change makes it so that, using the dotnet CLI, one can use `dotnet run -lp Seed-Data` to seed the database programmatically.